### PR TITLE
Mpris player name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@
 # vendor/
 
 dist/
+
+# Built executable
+sptlrx
+
+# IDE files
+.vscode/

--- a/config/config.go
+++ b/config/config.go
@@ -59,6 +59,10 @@ type Config struct {
 	Mopidy struct {
 		Address string `default:"127.0.0.1:6680" yaml:"address"`
 	} `yaml:"mopidy"`
+
+	Mpris struct {
+		Name string `default:"" yaml:"name"`
+	} `yaml:"mpris"`
 }
 
 func New() *Config {
@@ -193,7 +197,7 @@ func GetPlayer(conf *Config) (player.Player, error) {
 			conf.Mopidy.Address,
 		)
 	case "mpris":
-		return mpris.New()
+		return mpris.New(conf.Mpris.Name)
 	}
 	return nil, fmt.Errorf("unknown player: \"%s\"", conf.Player)
 }

--- a/services/mpris/mpris.go
+++ b/services/mpris/mpris.go
@@ -10,7 +10,7 @@ import (
 	"github.com/godbus/dbus/v5"
 )
 
-func New() (*Client, error) {
+func New(name string) (*Client, error) {
 	if runtime.GOOS == "windows" {
 		return nil, errors.New("windows is not supported")
 	}
@@ -19,12 +19,22 @@ func New() (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Client{conn}, nil
+	return &Client{name, conn}, nil
 }
 
 // Client implements player.Player
 type Client struct {
+	name string
 	conn *dbus.Conn
+}
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Client) getPlayer() (*mpris.Player, error) {
@@ -36,7 +46,14 @@ func (p *Client) getPlayer() (*mpris.Player, error) {
 		return nil, nil
 	}
 
-	return mpris.New(p.conn, names[0]), nil
+	if len(p.name) == 0 {
+		return mpris.New(p.conn, names[0]), nil
+	}
+
+	if !stringInSlice(p.name, names) {
+		return nil, err
+	}
+	return mpris.New(p.conn, p.name), nil
 }
 
 func (p *Client) State() (*player.State, error) {


### PR DESCRIPTION
Add an option in the config file to specify the Mpris player name. This prevents sptlrx from trying to load lyrics to a video which is (later) opened in a browser for example when the "real" player is running in the background and not first in the list.

Name should be specified as follows: 
```
mpris: 
    name: "org.mpris.MediaPlayer2.spotifyd" 
```

where `spotifyd` should be replaced with the player name as given by `playerctl -l`.
