### PR TITLE
MPRIS: Add support for pattern matching

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"sptlrx/player"
@@ -84,7 +84,7 @@ func Load() (*Config, error) {
 			// workaround for compatibility with old versions
 			cookiePath := path.Join(Directory, "cookie.txt")
 			if cookieFile, err := os.Open(cookiePath); err == nil {
-				b, err := ioutil.ReadAll(cookieFile)
+				b, err := io.ReadAll(cookieFile)
 				cookieFile.Close()
 
 				os.Remove(cookiePath)

--- a/services/mpris/mpris_linux.go
+++ b/services/mpris/mpris_linux.go
@@ -1,6 +1,7 @@
 package mpris
 
 import (
+	"path"
 	"sptlrx/player"
 	"strings"
 
@@ -38,8 +39,12 @@ func (c *Client) getPlayer() (*mpris.Player, error) {
 	// iterating over configured names
 	for _, p := range c.players {
 		for _, player := range players {
-			// trim "org.mpris.MediaPlayer2."
-			if player[23:] == p {
+			// support pattern matching
+			match, err := path.Match("org.mpris.MediaPlayer2."+p, player)
+			if err != nil {
+				return nil, err
+			}
+			if match {
 				return mpris.New(conn, player), nil
 			}
 		}


### PR DESCRIPTION
Closes #33, adding pattern matching to `players` array.

I also made a minor edit in `config.go` as `ioutil` has been deprecated in Go 1.16 and the function moved to simply `io`.