### PR TITLE
DRAFT: Multi-player, Multi-lyric source enhancements (IN PROGRESS)

### DIFF
--- a/cmd/pipe.go
+++ b/cmd/pipe.go
@@ -21,17 +21,17 @@ var pipeCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("couldn't load config: %w", err)
 		}
-		player, err := loadPlayer(conf)
+		players, err := loadPlayers(conf)
 		if err != nil {
-			return fmt.Errorf("couldn't load player: %w", err)
+			return fmt.Errorf("couldn't load players: %w", err)
 		}
-		provider, err := loadProvider(conf, player)
+		provider, err := loadProvider(conf)
 		if err != nil {
 			return fmt.Errorf("couldn't load provider: %w", err)
 		}
 
 		ch := make(chan pool.Update)
-		go pool.Listen(player, provider, conf, ch)
+		go pool.Listen(players, provider, conf, ch)
 
 		for update := range ch {
 			printUpdate(update, conf)

--- a/lyrics/lyrics.go
+++ b/lyrics/lyrics.go
@@ -1,7 +1,10 @@
 package lyrics
 
+import "sptlrx/player"
+
 type Provider interface {
-	Lyrics(id, query string) ([]Line, error)
+	Lyrics(state player.State) ([]Line, error)
+	Name() string
 }
 
 type Line struct {

--- a/player/player.go
+++ b/player/player.go
@@ -8,7 +8,11 @@ type State struct {
 	// ID of the current track.
 	ID string
 	// Query is a string that can be used to find lyrics.
-	Query string
+	TrackNumber int
+	Artist      string
+	Album       string
+	Title       string
+	SongPath    string
 	// Position of the current track in ms.
 	Position int
 	// Playing means whether the track is playing at the moment.

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -47,7 +47,7 @@ func Listen(
 			if newState.ID != state.ID {
 				changed = true
 				if newState.ID != "" {
-					newLines, err := provider.Lyrics(newState.ID, newState.Query)
+					newLines, err := provider.Lyrics(newState.State)
 					if err != nil {
 						state.Err = err
 					}
@@ -100,12 +100,14 @@ func listenPlayer(player player.Player, ch chan playerState, interval int) {
 		st := playerState{Err: err}
 		if state != nil {
 			st.ID = state.ID
-			st.Query = state.Query
+			st.Album = state.Album
+			st.Artist = state.Artist
+			st.Title = state.Title
+			st.TrackNumber = state.TrackNumber
 			st.Playing = state.Playing
 			st.Position = state.Position
 		}
 		ch <- st
-
 		time.Sleep(time.Millisecond * time.Duration(interval))
 	}
 }

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -18,13 +18,15 @@ type Update struct {
 
 // Listen polls for lyrics updates and writes them to the channel.
 func Listen(
-	player player.Player,
+	players []*player.Player,
 	provider lyrics.Provider,
 	conf *config.Config,
 	ch chan Update,
 ) {
 	stateCh := make(chan playerState)
-	go listenPlayer(player, stateCh, conf.UpdateInterval)
+	for _, p := range players {
+		go listenPlayer(*p, stateCh, conf.UpdateInterval)
+	}
 
 	ticker := time.NewTicker(
 		time.Millisecond * time.Duration(conf.TimerInterval),

--- a/services/browser/browser.go
+++ b/services/browser/browser.go
@@ -154,7 +154,8 @@ func (c *Client) State() (*player.State, error) {
 	}
 	return &player.State{
 		ID:       query,
-		Query:    query,
+		Artist:   c.artist,
+		Title:    c.title,
 		Position: position,
 		Playing:  c.state == playing,
 	}, nil

--- a/services/browser/browser.go
+++ b/services/browser/browser.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"sptlrx/player"
 	"strconv"
 	"strings"
@@ -24,7 +25,7 @@ const (
 	playing
 )
 
-func New(port int) (*Client, error) {
+func New(port int) (player.Player, error) {
 	c := &Client{}
 	return c, c.start(port)
 }
@@ -73,6 +74,8 @@ func (c *Client) handler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			return
 		}
+
+		os.Stderr.WriteString("BRWSR: msg: " + string(msg) + "\n")
 		if t != websocket.MessageText || len(msg) == 0 {
 			continue
 		}
@@ -81,6 +84,8 @@ func (c *Client) handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *Client) processMessage(msg string) {
+
+	os.Stderr.WriteString("BRWSR: Recieved message" + "\n")
 	spaceIndex := strings.IndexByte(msg, ' ')
 	if spaceIndex == -1 {
 		return
@@ -140,20 +145,25 @@ func (c *Client) State() (*player.State, error) {
 	if c.state == stopped {
 		return nil, nil
 	}
+	os.Stderr.WriteString("BRWSR: Found Song" + "\n")
 
-	var query string
+	var id string
 	if c.artist != "" {
-		query = c.artist + " " + c.title
+		id = c.artist + " " + c.title
 	} else {
-		query = c.title
+		id = c.title
 	}
+
+	os.Stderr.WriteString("BRWSR: Artist" + c.artist + "\n")
+	os.Stderr.WriteString("BRWSR: Title" + c.title + "\n")
+	os.Stderr.WriteString("BRWSR: Position" + strconv.Itoa(c.position) + "\n")
 
 	position := c.position
 	if c.state != paused {
 		position += int(time.Since(c.updateTime).Milliseconds())
 	}
 	return &player.State{
-		ID:       query,
+		ID:       id,
 		Artist:   c.artist,
 		Title:    c.title,
 		Position: position,

--- a/services/combo/combo.go
+++ b/services/combo/combo.go
@@ -1,0 +1,32 @@
+package combo
+
+import (
+	"sptlrx/lyrics"
+	"sptlrx/player"
+)
+
+func New(providers []lyrics.Provider) (*ComboClient, error) {
+
+	return &ComboClient{providers: providers}, nil
+}
+
+type ComboClient struct {
+	providers []lyrics.Provider
+}
+
+func (c *ComboClient) Lyrics(state player.State) ([]lyrics.Line, error) {
+	for _, p := range c.providers {
+		provider := p
+		newLines, err := provider.Lyrics(state)
+		if err != nil || newLines == nil {
+			continue
+		} else {
+			return newLines, nil
+		}
+	}
+	return nil, nil
+}
+
+func (c *ComboClient) Name() string {
+	return "COMBO"
+}

--- a/services/hosted/hosted.go
+++ b/services/hosted/hosted.go
@@ -6,10 +6,11 @@ import (
 	"net/http"
 	"net/url"
 	"sptlrx/lyrics"
+	"sptlrx/player"
 )
 
 // Host your own: https://github.com/raitonoberu/lyricsapi
-func New(host string) *Client {
+func New(host string) lyrics.Provider {
 	return &Client{
 		host: host,
 	}
@@ -20,7 +21,9 @@ type Client struct {
 	host string
 }
 
-func (c *Client) Lyrics(id, query string) ([]lyrics.Line, error) {
+func (c *Client) Lyrics(state player.State) ([]lyrics.Line, error) {
+
+	query := state.Artist + " " + state.Title
 	var url = fmt.Sprintf("https://%s/api/lyrics?name=%s", c.host, url.QueryEscape(query))
 
 	req, _ := http.NewRequest("GET", url, nil)
@@ -32,5 +35,13 @@ func (c *Client) Lyrics(id, query string) ([]lyrics.Line, error) {
 
 	var result []lyrics.Line
 	err = json.NewDecoder(resp.Body).Decode(&result)
-	return result, err
+	if len(result) > 0 {
+		return result, err
+	} else {
+		return nil, err
+	}
+}
+
+func (c *Client) Name() string {
+	return "HOSTD"
 }

--- a/services/hosted/hosted.go
+++ b/services/hosted/hosted.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"sptlrx/lyrics"
 	"sptlrx/player"
 )
@@ -29,6 +30,7 @@ func (c *Client) Lyrics(state player.State) ([]lyrics.Line, error) {
 	req, _ := http.NewRequest("GET", url, nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
+		os.Stderr.WriteString("HOSTD: Could not find lyrics" + "\n")
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -44,8 +46,10 @@ func (c *Client) Lyrics(state player.State) ([]lyrics.Line, error) {
 		// if result[0].Time < 10 {
 		// 	result[0].Time = 10
 		// }
+		os.Stderr.WriteString("HOSTD: Found Lyrics" + "\n")
 		return result, nil
 	} else {
+		os.Stderr.WriteString("HOSTD: Empty Lyrics" + "\n")
 		return nil, err
 	}
 }

--- a/services/hosted/hosted.go
+++ b/services/hosted/hosted.go
@@ -36,7 +36,15 @@ func (c *Client) Lyrics(state player.State) ([]lyrics.Line, error) {
 	var result []lyrics.Line
 	err = json.NewDecoder(resp.Body).Decode(&result)
 	if len(result) > 0 {
-		return result, err
+		// var header []lyrics.Line
+		// header = append(header, lyrics.Line{
+		// 	Time:  0,
+		// 	Words: "Loading from Hosted...",
+		// })
+		// if result[0].Time < 10 {
+		// 	result[0].Time = 10
+		// }
+		return result, nil
 	} else {
 		return nil, err
 	}

--- a/services/local/local.go
+++ b/services/local/local.go
@@ -53,7 +53,16 @@ func (c *Client) Lyrics(state player.State) ([]lyrics.Line, error) {
 	}
 	defer reader.Close()
 
-	return parseLrcFile(reader), nil
+	lys := parseLrcFile(reader)
+	// var header []lyrics.Line
+	// header = append(header, lyrics.Line{
+	// 	Time:  0,
+	// 	Words: "Loading from Local...",
+	// })
+	// if lys[0].Time < 10 {
+	// 	lys[0].Time = 10
+	// }
+	return lys, nil
 }
 
 func (c *Client) findFile(state player.State) *file {

--- a/services/local/local.go
+++ b/services/local/local.go
@@ -44,8 +44,11 @@ func (c *Client) Lyrics(state player.State) ([]lyrics.Line, error) {
 	f := c.findFile(state)
 
 	if f == nil {
+		os.Stderr.WriteString("LOCAL: Could not find local lyrics" + "\n")
 		return nil, nil
 	}
+
+	os.Stderr.WriteString("LOCAL: Found lyrics at:" + f.Path + "\n")
 
 	reader, err := os.Open(f.Path)
 	if err != nil {

--- a/services/mopidy/mopidy.go
+++ b/services/mopidy/mopidy.go
@@ -71,12 +71,11 @@ func (c *Client) State() (*player.State, error) {
 		artist += a.Name
 	}
 
-	query := artist + " " + current.Result.Name
-
 	return &player.State{
 		ID:       current.Result.URI,
-		Query:    query,
+		Title:    current.Result.Name,
 		Position: position.Result,
+		Artist:   artist,
 		Playing:  state.Result == "playing",
 	}, err
 }

--- a/services/mopidy/mopidy.go
+++ b/services/mopidy/mopidy.go
@@ -8,7 +8,7 @@ import (
 	"sptlrx/player"
 )
 
-func New(address string) *Client {
+func New(address string) player.Player {
 	return &Client{address: address}
 }
 

--- a/services/mpd/mpd.go
+++ b/services/mpd/mpd.go
@@ -66,16 +66,10 @@ func (c *Client) State() (*player.State, error) {
 		artist = a
 	}
 
-	var query string
-	if artist != "" {
-		query = artist + " " + title
-	} else {
-		query = title
-	}
-
 	return &player.State{
 		ID:       status["songid"],
-		Query:    query,
+		Artist:   artist,
+		Title:    title,
 		Playing:  status["state"] == "play",
 		Position: int(elapsed) * 1000,
 	}, nil

--- a/services/mpd/mpd.go
+++ b/services/mpd/mpd.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fhs/gompd/mpd"
 )
 
-func New(address, password string) *Client {
+func New(address, password string) player.Player {
 	return &Client{
 		address:  address,
 		password: password,

--- a/services/mpris/mpris_unix.go
+++ b/services/mpris/mpris_unix.go
@@ -74,9 +74,24 @@ func (c *Client) State() (*player.State, error) {
 		return nil, err
 	}
 
-	var title string
+	var songPath string = ""
+	if p, ok := meta["xesam:url"].Value().(string); ok {
+		songPath = p
+	}
+
+	var trackNumber int = 0
+	if n, ok := meta["xesam:trackNumber"].Value().(int); ok {
+		trackNumber = n
+	}
+
+	var title string = ""
 	if t, ok := meta["xesam:title"].Value().(string); ok {
 		title = t
+	}
+
+	var album string = ""
+	if al, ok := meta["xesam:album"].Value().(string); ok {
+		album = al
 	}
 
 	var artist string
@@ -87,17 +102,14 @@ func (c *Client) State() (*player.State, error) {
 		artist = strings.Join(a.([]string), " ")
 	}
 
-	var query string
-	if artist != "" {
-		query = artist + " " + title
-	} else {
-		query = title
-	}
-
 	return &player.State{
-		ID:       query, // use query as id since mpris:trackid is broken
-		Query:    query,
-		Position: int(position * 1000), // secs to ms
-		Playing:  status == mpris.PlaybackPlaying,
+		ID:          songPath, // use query as id since mpris:trackid is broken
+		TrackNumber: trackNumber,
+		Artist:      artist,
+		Album:       album,
+		Title:       title,
+		SongPath:    songPath,
+		Position:    int(position * 1000), // secs to ms
+		Playing:     status == mpris.PlaybackPlaying,
 	}, err
 }

--- a/services/mpris/mpris_unix.go
+++ b/services/mpris/mpris_unix.go
@@ -3,14 +3,16 @@
 package mpris
 
 import (
+	"os"
 	"sptlrx/player"
+	"strconv"
 	"strings"
 
 	"github.com/Pauloo27/go-mpris"
 	"github.com/godbus/dbus/v5"
 )
 
-func New(players []string) (*Client, error) {
+func New(players []string) (player.Player, error) {
 	return &Client{players}, nil
 }
 
@@ -52,6 +54,8 @@ func (c *Client) getPlayer() (*mpris.Player, error) {
 }
 
 func (c *Client) State() (*player.State, error) {
+
+	os.Stderr.WriteString("MPRIS: Found Song" + "\n")
 	p, err := c.getPlayer()
 	if err != nil {
 		return nil, err
@@ -77,21 +81,25 @@ func (c *Client) State() (*player.State, error) {
 	var songPath string = ""
 	if p, ok := meta["xesam:url"].Value().(string); ok {
 		songPath = p
+		os.Stderr.WriteString("MPRIS: Path: " + songPath + "\n")
 	}
 
 	var trackNumber int = 0
 	if n, ok := meta["xesam:trackNumber"].Value().(int); ok {
 		trackNumber = n
+		os.Stderr.WriteString("MPRIS: TrackNum: " + strconv.Itoa(trackNumber) + "\n")
 	}
 
 	var title string = ""
 	if t, ok := meta["xesam:title"].Value().(string); ok {
 		title = t
+		os.Stderr.WriteString("MPRIS: Title: " + title + "\n")
 	}
 
 	var album string = ""
 	if al, ok := meta["xesam:album"].Value().(string); ok {
 		album = al
+		os.Stderr.WriteString("MPRIS: Album: " + album + "\n")
 	}
 
 	var artist string
@@ -101,6 +109,7 @@ func (c *Client) State() (*player.State, error) {
 	case []string:
 		artist = strings.Join(a.([]string), " ")
 	}
+	os.Stderr.WriteString("MPRIS: Artist: " + artist + "\n")
 
 	return &player.State{
 		ID:          songPath, // use query as id since mpris:trackid is broken

--- a/services/spotify/spotify.go
+++ b/services/spotify/spotify.go
@@ -77,15 +77,20 @@ func (c *Client) State() (*player.State, error) {
 	}, nil
 }
 
-func (c *Client) Lyrics(id, query string) ([]lyrics.Line, error) {
-	if strings.HasPrefix(id, "spotify:") {
-		return c.lyrics(id[8:])
+func (c *Client) Lyrics(state player.State) ([]lyrics.Line, error) {
+	if strings.HasPrefix(state.ID, "spotify:") {
+		return c.lyrics(state.ID[8:])
 	}
-	id, err := c.search(query)
+	id, err := c.search(state.Artist + " " + state.Title)
 	if err != nil {
 		return nil, err
 	}
-	return c.lyrics(id)
+	lys, err := c.lyrics(id)
+	if len(lys) > 0 && err != nil {
+		return lys, err
+	} else {
+		return nil, err
+	}
 }
 
 func (c *Client) search(query string) (string, error) {
@@ -241,4 +246,8 @@ type searchBody struct {
 		} `json:"items"`
 		Total int `json:"total"`
 	} `json:"tracks"`
+}
+
+func (c *Client) Name() string {
+	return "SPOTI"
 }

--- a/services/spotify/spotify.go
+++ b/services/spotify/spotify.go
@@ -87,6 +87,14 @@ func (c *Client) Lyrics(state player.State) ([]lyrics.Line, error) {
 	}
 	lys, err := c.lyrics(id)
 	if len(lys) > 0 && err != nil {
+		// var header []lyrics.Line
+		// header = append(header, lyrics.Line{
+		// 	Time:  0,
+		// 	Words: "Loading from Spotify...",
+		// })
+		// if lys[0].Time < 10 {
+		// 	lys[0].Time = 10
+		// }
 		return lys, err
 	} else {
 		return nil, err

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -104,6 +104,7 @@ func (m *Model) View() string {
 		return ""
 	}
 	if m.state.Err != nil && !m.Config.IgnoreErrors {
+		os.Stderr.WriteString(m.state.Err.Error())
 		return gloss.PlaceVertical(
 			m.h, gloss.Center,
 			m.styleCurrent.

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -104,7 +104,6 @@ func (m *Model) View() string {
 		return ""
 	}
 	if m.state.Err != nil && !m.Config.IgnoreErrors {
-		os.Stderr.WriteString(m.state.Err.Error())
 		return gloss.PlaceVertical(
 			m.h, gloss.Center,
 			m.styleCurrent.


### PR DESCRIPTION
I'm not a Go developer, so I'm still working on how to do what I want to do, but generally the idea is to list multiple players in the configuration and multiple lyric source configurations, so that if the hosted or Spotify lyric sources don't provide lyrics, but the user has .lrc files present, it will use those as a backup.

Also, looking into changing how the query data is passed to the lyrics providers, so that we can check the local file sources to make sure that the album, artist, and song title are present, and also if the path of the local MPRIS player specifies a specific file path, check that file path for a matching .lrc file.

If any Go developers have ideas on how to make it listen to multiple players, please let me know, I'm a C# guy.