### PR TITLE
Fix: typo in config file for `underline`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ style:
     foreground: ""
     bold: true
     italic: false
-    undeline: false
+    underline: false
     strikethrough: false
     blink: false
     faint: false
@@ -103,7 +103,7 @@ style:
     foreground: ""
     bold: true
     italic: false
-    undeline: false
+    underline: false
     strikethrough: false
     blink: false
     faint: false
@@ -114,7 +114,7 @@ style:
     foreground: ""
     bold: false
     italic: false
-    undeline: false
+    underline: false
     strikethrough: false
     blink: false
     faint: true

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -163,7 +163,7 @@ func parseStyleFlag(value string) config.Style {
 		case "italic":
 			style.Italic = true
 		case "underline":
-			style.Undeline = true
+			style.Underline = true
 		case "strikethrough":
 			style.Strikethrough = true
 		case "blink":

--- a/config/config.go
+++ b/config/config.go
@@ -124,7 +124,7 @@ type Style struct {
 
 	Bold          bool `yaml:"bold"`
 	Italic        bool `yaml:"italic"`
-	Undeline      bool `yaml:"undeline"`
+	Underline      bool `yaml:"underline"`
 	Strikethrough bool `yaml:"strikethrough"`
 	Blink         bool `yaml:"blink"`
 	Faint         bool `yaml:"faint"`
@@ -146,7 +146,7 @@ func (s Style) Parse() gloss.Style {
 	if s.Italic {
 		style = style.Italic(true)
 	}
-	if s.Undeline {
+	if s.Underline {
 		style = style.Underline(true)
 	}
 	if s.Strikethrough {


### PR DESCRIPTION
Fixed the typo identified in #41, the option in the config is now `underline`.

## Related Issues
Closes #41 

## Platforms Tested
- [x] NixOS 24.05 (Uakari)