### PR TITLE
fix: trim .ext from title to optimize query.

### DIFF
--- a/services/mpris/mpris_unix.go
+++ b/services/mpris/mpris_unix.go
@@ -5,6 +5,8 @@ package mpris
 import (
 	"sptlrx/player"
 	"strings"
+	"net/url"
+	"path/filepath"
 
 	"github.com/Pauloo27/go-mpris"
 	"github.com/godbus/dbus/v5"
@@ -77,6 +79,15 @@ func (c *Client) State() (*player.State, error) {
 	var title string
 	if t, ok := meta["xesam:title"].Value().(string); ok {
 		title = t
+	}
+
+	// In case the player uses the file name with extension as title
+	if u, ok := meta["xesam:url"].Value().(string); ok {
+		u, err := url.Parse(u)
+		if err == nil {
+			ext := filepath.Ext(u.Path)
+			title = strings.TrimSuffix(title, ext)
+		}
 	}
 
 	var artist string


### PR DESCRIPTION
The unexpected .<ext> field in the title directly
corrupts local.go:findFile, so that the last part
of the title never accurately matches the lrc file.


---

I'm using Rhythmbox to play local music and the lyrics are also local. Then I noticed that for files with missing metatags, sptlrx always confused different songs by the same artist.

After debugging, I found that the reason is that Rhythmbox will use the file name together with its extension as the fall-back title, and when matching local lyrics, the extension will be processed and glued together with another part at the end of the file name -- usually the real title of the song. 

This means that unless this mechanism is known in advance and all lyric files are renamed accordingly, accurate matching is impossible to occur for a player like Rhythmbox.

This fix may also introduce new issues with certain file/player combinations, such as when the song title contains a dot but the url does not contain the file extension. But I think this situation should be rare enough. 

---

Maybe it would be better to put meta["xesam:url"] into the player.State structure, so that local.go can compare the file extensions by itself, and also get the accurate lrc file with the same name based on the url without configuring the lyrics directory.