### PR TITLE
Local lyric uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,9 @@ local:
   folder: ""
 ```
 
-If you want to use your local collection of `.lrc` files to display lyrics, specify the folder to scan. The application will use files with the most similar name. All other lyrics sources will be disabled.
+If you want to use your local collection of `.lrc` files to display lyrics, specify the folder to scan. The application will use files with the most similar name. When used in conjunction with a local player, it will first look for a file with the same path as the music file, with the extension replaced by `.lrc`.
+
+All other lyrics sources will be disabled.
 
 ## Information
 

--- a/lyrics/lyrics.go
+++ b/lyrics/lyrics.go
@@ -1,7 +1,9 @@
 package lyrics
 
+import "sptlrx/player"
+
 type Provider interface {
-	Lyrics(id, query string) ([]Line, error)
+	Lyrics(track *player.TrackMetadata) ([]Line, error)
 }
 
 type Line struct {

--- a/player/player.go
+++ b/player/player.go
@@ -4,11 +4,18 @@ type Player interface {
 	State() (*State, error)
 }
 
-type State struct {
+type TrackMetadata struct {
 	// ID of the current track.
 	ID string
+	// URI is the path to the local music file, if it exists.
+	// May be either absolute or relative to the local music directory (configured in "local" source).
+	Uri string
 	// Query is a string that can be used to find lyrics.
 	Query string
+}
+
+type State struct {
+	Track TrackMetadata
 	// Position of the current track in ms.
 	Position int
 	// Playing means whether the track is playing at the moment.

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -44,10 +44,10 @@ func Listen(
 		case newState := <-stateCh:
 			lastUpdate = time.Now()
 
-			if newState.ID != state.ID {
+			if newState.Track.ID != state.Track.ID {
 				changed = true
-				if newState.ID != "" {
-					newLines, err := provider.Lyrics(newState.ID, newState.Query)
+				if newState.Track.ID != "" {
+					newLines, err := provider.Lyrics(&newState.Track)
 					if err != nil {
 						state.Err = err
 					}
@@ -99,8 +99,7 @@ func listenPlayer(player player.Player, ch chan playerState, interval int) {
 
 		st := playerState{Err: err}
 		if state != nil {
-			st.ID = state.ID
-			st.Query = state.Query
+			st.Track = state.Track
 			st.Playing = state.Playing
 			st.Position = state.Position
 		}

--- a/services/browser/browser.go
+++ b/services/browser/browser.go
@@ -153,8 +153,10 @@ func (c *Client) State() (*player.State, error) {
 		position += int(time.Since(c.updateTime).Milliseconds())
 	}
 	return &player.State{
-		ID:       query,
-		Query:    query,
+		Track:    player.TrackMetadata{
+			ID:       query,
+			Query:    query,
+		},
 		Position: position,
 		Playing:  c.state == playing,
 	}, nil

--- a/services/hosted/hosted.go
+++ b/services/hosted/hosted.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"sptlrx/lyrics"
+	"sptlrx/player"
 )
 
 // Host your own: https://github.com/raitonoberu/lyricsapi
@@ -20,8 +21,8 @@ type Client struct {
 	host string
 }
 
-func (c *Client) Lyrics(id, query string) ([]lyrics.Line, error) {
-	var url = fmt.Sprintf("https://%s/api/lyrics?name=%s", c.host, url.QueryEscape(query))
+func (c *Client) Lyrics(track *player.TrackMetadata) ([]lyrics.Line, error) {
+	var url = fmt.Sprintf("https://%s/api/lyrics?name=%s", c.host, url.QueryEscape(track.Query))
 
 	req, _ := http.NewRequest("GET", url, nil)
 	resp, err := http.DefaultClient.Do(req)

--- a/services/local/local.go
+++ b/services/local/local.go
@@ -78,7 +78,6 @@ func (c *Client) findFile(track *player.TrackMetadata) string {
 		}
 		absLyricsUri := strings.TrimSuffix(absUri, filepath.Ext(absUri)) + ".lrc"
 		if _, err := os.Stat(absLyricsUri); err == nil {
-			fmt.Print(absLyricsUri)
 			return absLyricsUri
 		}
 	}

--- a/services/mopidy/mopidy.go
+++ b/services/mopidy/mopidy.go
@@ -74,8 +74,10 @@ func (c *Client) State() (*player.State, error) {
 	query := artist + " " + current.Result.Name
 
 	return &player.State{
-		ID:       current.Result.URI,
-		Query:    query,
+		Track:    player.TrackMetadata{
+			ID:    current.Result.URI,
+			Query: query,
+		},
 		Position: position.Result,
 		Playing:  state.Result == "playing",
 	}, err

--- a/services/mpd/mpd.go
+++ b/services/mpd/mpd.go
@@ -74,8 +74,11 @@ func (c *Client) State() (*player.State, error) {
 	}
 
 	return &player.State{
-		ID:       status["songid"],
-		Query:    query,
+		Track:    player.TrackMetadata{
+			ID:    status["songid"],
+			Uri:   current["file"],
+			Query: query,
+		},
 		Playing:  status["state"] == "play",
 		Position: int(elapsed) * 1000,
 	}, nil

--- a/services/mpris/mpris_unix.go
+++ b/services/mpris/mpris_unix.go
@@ -81,11 +81,14 @@ func (c *Client) State() (*player.State, error) {
 		title = t
 	}
 
+	var uri string
 	// In case the player uses the file name with extension as title
 	if u, ok := meta["xesam:url"].Value().(string); ok {
 		u, err := url.Parse(u)
 		if err == nil {
 			ext := filepath.Ext(u.Path)
+			uri = u.Path
+			// some players use filename as title when tag is absent => trim extension from title
 			title = strings.TrimSuffix(title, ext)
 		}
 	}
@@ -106,8 +109,11 @@ func (c *Client) State() (*player.State, error) {
 	}
 
 	return &player.State{
-		ID:       query, // use query as id since mpris:trackid is broken
-		Query:    query,
+		Track: player.TrackMetadata{
+			ID:    query, // use query as id since mpris:trackid is broken
+			Uri:   uri,
+			Query: query,
+		},
 		Position: int(position * 1000), // secs to ms
 		Playing:  status == mpris.PlaybackPlaying,
 	}, err

--- a/services/spotify/spotify.go
+++ b/services/spotify/spotify.go
@@ -33,21 +33,21 @@ func (c *Client) State() (*player.State, error) {
 	}
 
 	return &player.State{
-		ID:       "spotify:" + result.Item.ID,
+		Track:    player.TrackMetadata{ID: "spotify:" + result.Item.ID},
 		Position: result.Progress,
 		Playing:  result.Playing,
 	}, nil
 }
 
-func (c *Client) Lyrics(id, query string) ([]lyrics.Line, error) {
+func (c *Client) Lyrics(track *player.TrackMetadata) ([]lyrics.Line, error) {
 	var (
 		result *lyricsapi.LyricsResult
 		err    error
 	)
-	if strings.HasPrefix(id, "spotify:") {
-		result, err = c.api.GetByID(id[8:])
+	if strings.HasPrefix(track.ID, "spotify:") {
+		result, err = c.api.GetByID(track.ID[8:])
 	} else {
-		result, err = c.api.GetByName(query)
+		result, err = c.api.GetByName(track.Query)
 	}
 
 	if err != nil {


### PR DESCRIPTION
The current local lyric provider is a bit naive in its searching. I believe this is a known issue, for which the proper solution might be quite complex. This PR proposes an easy win to cover what I assume is a common case.

I believe that when the local lyric source is used, it will often be used in conjunction with a local music library (this is my personal set up, and it currently doesn't work very well with `sptlrx`). Therefore, it seems worthwhile to attempt to fetch the lyrics from a file with the same name as the local music file (if there is any), with the extension replaced by `.lrc`. If no such file exists, we would fall back to the current mechanism.

This PR implements this behavior for the MPD and MPRIS sources. To this end it contains a slight refactor to encapsulate the lyrics providers' input in a `TrackMetadata` struct. An additional `Uri` field is added there, which will be set if a local file is known for the currently playing track. The local lyric provider will then use this `Uri` to attempt to fetch an associated `.lrc` file.

I should disclaim that I have no prior experience with Go, so I'm unfamiliar with its conventions. I tried to infer from the rest of the code base, but please feel free to point out any code smells.