### PR TITLE
Fix garbled Cyrillic in LRC parsing, use /api/get for lrclib

### DIFF
--- a/lyrics/lyrics.go
+++ b/lyrics/lyrics.go
@@ -1,5 +1,10 @@
 package lyrics
 
+import (
+	"strconv"
+	"strings"
+)
+
 type Provider interface {
 	Lyrics(artist, track string) ([]Line, error)
 }
@@ -11,4 +16,38 @@ type Line struct {
 
 func Timesynced(lines []Line) bool {
 	return len(lines) > 1 && lines[1].Time != 0
+}
+
+func IsTimestampLine(line string) bool {
+	if len(line) < 10 {
+		return false
+	}
+	return line[0] == '[' &&
+		line[1] >= '0' && line[1] <= '9' &&
+		line[2] >= '0' && line[2] <= '9' &&
+		line[3] == ':' &&
+		line[6] == '.' &&
+		strings.IndexByte(line, ']') > 6
+}
+
+func ParseLrcLine(line string) Line {
+	m, _ := strconv.Atoi(line[1:3])
+	s, _ := strconv.Atoi(line[4:6])
+
+	closeBracket := strings.IndexByte(line, ']')
+
+	msStr := line[7:closeBracket]
+	ms, _ := strconv.Atoi(msStr)
+	if len(msStr) == 2 {
+		ms *= 10
+	} else if len(msStr) == 1 {
+		ms *= 100
+	}
+
+	words := strings.TrimSpace(line[closeBracket+1:])
+
+	return Line{
+		Time:  m*60*1000 + s*1000 + ms,
+		Words: words,
+	}
 }

--- a/lyrics/lyrics.go
+++ b/lyrics/lyrics.go
@@ -1,7 +1,7 @@
 package lyrics
 
 type Provider interface {
-	Lyrics(id, query string) ([]Line, error)
+	Lyrics(artist, track string) ([]Line, error)
 }
 
 type Line struct {

--- a/player/player.go
+++ b/player/player.go
@@ -7,8 +7,10 @@ type Player interface {
 type State struct {
 	// ID of the current track.
 	ID string
-	// Query is a string that can be used to find lyrics.
-	Query string
+	// Artist is the name of the artist(s).
+	Artist string
+	// Track is the name of the track.
+	Track string
 	// Position of the current track in ms.
 	Position int
 	// Playing means whether the track is playing at the moment.

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -99,11 +99,7 @@ func listenPlayer(player player.Player, ch chan playerState, interval int) {
 
 		st := playerState{Err: err}
 		if state != nil {
-			st.ID = state.ID
-			st.Artist = state.Artist
-			st.Track = state.Track
-			st.Playing = state.Playing
-			st.Position = state.Position
+			st.State = *state
 		}
 		ch <- st
 

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -47,7 +47,7 @@ func Listen(
 			if newState.ID != state.ID {
 				changed = true
 				if newState.ID != "" {
-					newLines, err := provider.Lyrics(newState.ID, newState.Query)
+					newLines, err := provider.Lyrics(newState.Artist, newState.Track)
 					if err != nil {
 						state.Err = err
 					}
@@ -100,7 +100,8 @@ func listenPlayer(player player.Player, ch chan playerState, interval int) {
 		st := playerState{Err: err}
 		if state != nil {
 			st.ID = state.ID
-			st.Query = state.Query
+			st.Artist = state.Artist
+			st.Track = state.Track
 			st.Playing = state.Playing
 			st.Position = state.Position
 		}

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestGetIndex(t *testing.T) {
 	service := lrclib.New()
-	lines, err := service.Lyrics("", "Death Grips No Love")
+	lines, err := service.Lyrics("Death Grips", "No Love")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/services/browser/browser.go
+++ b/services/browser/browser.go
@@ -141,20 +141,16 @@ func (c *Client) State() (*player.State, error) {
 		return nil, nil
 	}
 
-	var query string
-	if c.artist != "" {
-		query = c.artist + " " + c.title
-	} else {
-		query = c.title
-	}
+	id := c.artist + " " + c.title
 
 	position := c.position
 	if c.state != paused {
 		position += int(time.Since(c.updateTime).Milliseconds())
 	}
 	return &player.State{
-		ID:       query,
-		Query:    query,
+		ID:       id,
+		Artist:   c.artist,
+		Track:    c.title,
 		Position: position,
 		Playing:  c.state == playing,
 	}, nil

--- a/services/local/local.go
+++ b/services/local/local.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/raitonoberu/sptlrx/lyrics"
@@ -117,45 +116,10 @@ func parseLrcFile(reader io.Reader) []lyrics.Line {
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !isTimestampLine(line) {
+		if !lyrics.IsTimestampLine(line) {
 			continue
 		}
-		result = append(result, parseLrcLine(line))
+		result = append(result, lyrics.ParseLrcLine(line))
 	}
 	return result
-}
-
-// isTimestampLine checks if a line starts with a timestamp like [00:17.12]
-func isTimestampLine(line string) bool {
-	if len(line) < 10 {
-		return false
-	}
-	return line[0] == '[' &&
-		line[3] == ':' &&
-		line[6] == '.' &&
-		line[1] >= '0' && line[1] <= '9' &&
-		line[2] >= '0' && line[2] <= '9'
-}
-
-func parseLrcLine(line string) lyrics.Line {
-	// [00:00.00]text or [00:00.000] text
-	h, _ := strconv.Atoi(line[1:3])
-	m, _ := strconv.Atoi(line[4:6])
-
-	closeBracket := strings.IndexByte(line, ']')
-
-	msStr := line[7:closeBracket]
-	ms, _ := strconv.Atoi(msStr)
-	if len(msStr) == 2 {
-		ms *= 10
-	} else if len(msStr) == 1 {
-		ms *= 100
-	}
-
-	words := strings.TrimSpace(line[closeBracket+1:])
-
-	return lyrics.Line{
-		Time:  h*60*1000 + m*1000 + ms,
-		Words: words,
-	}
 }

--- a/services/local/local.go
+++ b/services/local/local.go
@@ -3,13 +3,14 @@ package local
 import (
 	"bufio"
 	"fmt"
-	"github.com/raitonoberu/sptlrx/lyrics"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/raitonoberu/sptlrx/lyrics"
 )
 
 var replacer = strings.NewReplacer(
@@ -38,7 +39,8 @@ type Client struct {
 	index []*file
 }
 
-func (c *Client) Lyrics(id, query string) ([]lyrics.Line, error) {
+func (c *Client) Lyrics(artist, track string) ([]lyrics.Line, error) {
+	query := artist + " " + track
 	f := c.findFile(query)
 	if f == nil {
 		return nil, nil
@@ -115,7 +117,7 @@ func parseLrcFile(reader io.Reader) []lyrics.Line {
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !strings.HasPrefix(line, "[") || len(line) < 10 {
+		if !isTimestampLine(line) {
 			continue
 		}
 		result = append(result, parseLrcLine(line))
@@ -123,14 +125,40 @@ func parseLrcFile(reader io.Reader) []lyrics.Line {
 	return result
 }
 
+// isTimestampLine checks if a line starts with a timestamp like [00:17.12]
+func isTimestampLine(line string) bool {
+	if len(line) < 10 {
+		return false
+	}
+	return line[0] == '[' &&
+		line[3] == ':' &&
+		line[6] == '.' &&
+		line[1] >= '0' && line[1] <= '9' &&
+		line[2] >= '0' && line[2] <= '9'
+}
+
 func parseLrcLine(line string) lyrics.Line {
-	// [00:00.00]text -> {"time": 0, "words": "text"}
+	// [00:00.00]text or [00:00.000] text
 	h, _ := strconv.Atoi(line[1:3])
 	m, _ := strconv.Atoi(line[4:6])
-	s, _ := strconv.Atoi(line[7:9])
+
+	closeBracket := strings.IndexByte(line, ']')
+
+	msStr := line[7:closeBracket]
+	ms, _ := strconv.Atoi(msStr)
+	if len(msStr) == 2 {
+		ms *= 10
+	} else if len(msStr) == 1 {
+		ms *= 100
+	}
+
+	words := line[closeBracket+1:]
+	if strings.HasPrefix(words, " ") {
+		words = words[1:]
+	}
 
 	return lyrics.Line{
-		Time:  h*60*1000 + m*1000 + s*10,
-		Words: line[10:],
+		Time:  h*60*1000 + m*1000 + ms,
+		Words: words,
 	}
 }

--- a/services/local/local.go
+++ b/services/local/local.go
@@ -152,10 +152,7 @@ func parseLrcLine(line string) lyrics.Line {
 		ms *= 100
 	}
 
-	words := line[closeBracket+1:]
-	if strings.HasPrefix(words, " ") {
-		words = words[1:]
-	}
+	words := strings.TrimSpace(line[closeBracket+1:])
 
 	return lyrics.Line{
 		Time:  h*60*1000 + m*1000 + ms,

--- a/services/lrclib/lrclib.go
+++ b/services/lrclib/lrclib.go
@@ -23,14 +23,58 @@ type Client struct {
 }
 
 // Client implements lyrics.Provider
-func (c *Client) Lyrics(id, query string) ([]lyrics.Line, error) {
+func (c *Client) Lyrics(artist, track string) ([]lyrics.Line, error) {
+	// try /api/get first (exact match, no caching issues)
+	lines, err := c.get(artist, track)
+	if err == nil && lines != nil {
+		return lines, nil
+	}
+
+	// fallback to /api/search
+	return c.search(artist + " " + track)
+}
+
+func (c *Client) get(artist, track string) ([]lyrics.Line, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	url := "https://lrclib.net/api/search?" + url.Values{
+	u := "https://lrclib.net/api/get?" + url.Values{
+		"artist_name": {artist},
+		"track_name":  {track},
+	}.Encode()
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+
+	var response lrclibTrack
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseTrack(response), nil
+}
+
+func (c *Client) search(query string) ([]lyrics.Line, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	u := "https://lrclib.net/api/search?" + url.Values{
 		"q": {query},
 	}.Encode()
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +105,7 @@ type lrclibTrack struct {
 
 func parseTrack(t lrclibTrack) []lyrics.Line {
 	if t.SyncedLyrics != "" {
-		return parceSynced(t)
+		return parseSynced(t)
 	}
 	if t.PlainLyrics != "" {
 		return parsePlain(t)
@@ -69,11 +113,14 @@ func parseTrack(t lrclibTrack) []lyrics.Line {
 	return nil
 }
 
-func parceSynced(r lrclibTrack) []lyrics.Line {
+func parseSynced(r lrclibTrack) []lyrics.Line {
 	lines := strings.Split(r.SyncedLyrics, "\n")
-	result := make([]lyrics.Line, len(lines))
-	for i, line := range lines {
-		result[i] = parseLrcLine(line)
+	result := make([]lyrics.Line, 0, len(lines))
+	for _, line := range lines {
+		if !isTimestampLine(line) {
+			continue
+		}
+		result = append(result, parseLrcLine(line))
 	}
 	return result
 }
@@ -87,16 +134,40 @@ func parsePlain(r lrclibTrack) []lyrics.Line {
 	return result
 }
 
-func parseLrcLine(line string) lyrics.Line {
-	// "[00:17.12] whatever"
-	if len(line) < 11 {
-		return lyrics.Line{}
+// isTimestampLine checks if a line starts with a timestamp like [00:17.12]
+func isTimestampLine(line string) bool {
+	if len(line) < 10 {
+		return false
 	}
+	return line[0] == '[' &&
+		line[3] == ':' &&
+		line[6] == '.' &&
+		line[1] >= '0' && line[1] <= '9' &&
+		line[2] >= '0' && line[2] <= '9'
+}
+
+func parseLrcLine(line string) lyrics.Line {
+	// "[00:17.12] text" or "[00:17.123]text"
 	m, _ := strconv.Atoi(line[1:3])
 	s, _ := strconv.Atoi(line[4:6])
-	ms, _ := strconv.Atoi(line[7:9])
+
+	closeBracket := strings.IndexByte(line, ']')
+
+	msStr := line[7:closeBracket]
+	ms, _ := strconv.Atoi(msStr)
+	if len(msStr) == 2 {
+		ms *= 10
+	} else if len(msStr) == 1 {
+		ms *= 100
+	}
+
+	words := line[closeBracket+1:]
+	if strings.HasPrefix(words, " ") {
+		words = words[1:]
+	}
+
 	return lyrics.Line{
-		Time:  m*60*1000 + s*1000 + ms*10,
-		Words: line[11:],
+		Time:  m*60*1000 + s*1000 + ms,
+		Words: words,
 	}
 }

--- a/services/lrclib/lrclib.go
+++ b/services/lrclib/lrclib.go
@@ -161,10 +161,7 @@ func parseLrcLine(line string) lyrics.Line {
 		ms *= 100
 	}
 
-	words := line[closeBracket+1:]
-	if strings.HasPrefix(words, " ") {
-		words = words[1:]
-	}
+	words := strings.TrimSpace(line[closeBracket+1:])
 
 	return lyrics.Line{
 		Time:  m*60*1000 + s*1000 + ms,

--- a/services/lrclib/lrclib.go
+++ b/services/lrclib/lrclib.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
@@ -24,13 +23,9 @@ type Client struct {
 
 // Client implements lyrics.Provider
 func (c *Client) Lyrics(artist, track string) ([]lyrics.Line, error) {
-	// try /api/get first (exact match, no caching issues)
-	lines, err := c.get(artist, track)
-	if err == nil && lines != nil {
-		return lines, nil
+	if artist != "" && track != "" {
+		return c.get(artist, track)
 	}
-
-	// fallback to /api/search
 	return c.search(artist + " " + track)
 }
 
@@ -117,10 +112,10 @@ func parseSynced(r lrclibTrack) []lyrics.Line {
 	lines := strings.Split(r.SyncedLyrics, "\n")
 	result := make([]lyrics.Line, 0, len(lines))
 	for _, line := range lines {
-		if !isTimestampLine(line) {
+		if !lyrics.IsTimestampLine(line) {
 			continue
 		}
-		result = append(result, parseLrcLine(line))
+		result = append(result, lyrics.ParseLrcLine(line))
 	}
 	return result
 }
@@ -132,39 +127,4 @@ func parsePlain(r lrclibTrack) []lyrics.Line {
 		result[i] = lyrics.Line{Words: line}
 	}
 	return result
-}
-
-// isTimestampLine checks if a line starts with a timestamp like [00:17.12]
-func isTimestampLine(line string) bool {
-	if len(line) < 10 {
-		return false
-	}
-	return line[0] == '[' &&
-		line[3] == ':' &&
-		line[6] == '.' &&
-		line[1] >= '0' && line[1] <= '9' &&
-		line[2] >= '0' && line[2] <= '9'
-}
-
-func parseLrcLine(line string) lyrics.Line {
-	// "[00:17.12] text" or "[00:17.123]text"
-	m, _ := strconv.Atoi(line[1:3])
-	s, _ := strconv.Atoi(line[4:6])
-
-	closeBracket := strings.IndexByte(line, ']')
-
-	msStr := line[7:closeBracket]
-	ms, _ := strconv.Atoi(msStr)
-	if len(msStr) == 2 {
-		ms *= 10
-	} else if len(msStr) == 1 {
-		ms *= 100
-	}
-
-	words := strings.TrimSpace(line[closeBracket+1:])
-
-	return lyrics.Line{
-		Time:  m*60*1000 + s*1000 + ms,
-		Words: words,
-	}
 }

--- a/services/mopidy/mopidy.go
+++ b/services/mopidy/mopidy.go
@@ -71,11 +71,10 @@ func (c *Client) State() (*player.State, error) {
 		artist += a.Name
 	}
 
-	query := artist + " " + current.Result.Name
-
 	return &player.State{
 		ID:       current.Result.URI,
-		Query:    query,
+		Artist:   artist,
+		Track:    current.Result.Name,
 		Position: position.Result,
 		Playing:  state.Result == "playing",
 	}, err

--- a/services/mpd/mpd.go
+++ b/services/mpd/mpd.go
@@ -67,16 +67,10 @@ func (c *Client) State() (*player.State, error) {
 		artist = a
 	}
 
-	var query string
-	if artist != "" {
-		query = artist + " " + title
-	} else {
-		query = title
-	}
-
 	return &player.State{
 		ID:       status["songid"],
-		Query:    query,
+		Artist:   artist,
+		Track:    title,
 		Playing:  status["state"] == "play",
 		Position: int(elapsed * 1000), // secs to ms
 	}, nil

--- a/services/mpris/mpris_unix.go
+++ b/services/mpris/mpris_unix.go
@@ -98,16 +98,12 @@ func (c *Client) State() (*player.State, error) {
 		artist = strings.Join(a.([]string), " ")
 	}
 
-	var query string
-	if artist != "" {
-		query = artist + " " + title
-	} else {
-		query = title
-	}
+	id := artist + " " + title
 
 	return &player.State{
-		ID:       query, // use query as id since mpris:trackid is broken
-		Query:    query,
+		ID:       id, // use artist+title as id since mpris:trackid is broken
+		Artist:   artist,
+		Track:    title,
 		Position: int(position * 1000), // secs to ms
 		Playing:  status == mpris.PlaybackPlaying,
 	}, err

--- a/services/spotify/spotify.go
+++ b/services/spotify/spotify.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/raitonoberu/sptlrx/player"
@@ -64,17 +65,17 @@ func (c *Client) State() (*player.State, error) {
 		return nil, err
 	}
 
-	artist := ""
+	var b strings.Builder
 	for i, a := range state.Item.Artists {
 		if i != 0 {
-			artist += " "
+			b.WriteByte(' ')
 		}
-		artist += a.Name
+		b.WriteString(a.Name)
 	}
 
 	return &player.State{
 		ID:       state.Item.ID,
-		Artist:   artist,
+		Artist:   b.String(),
 		Track:    state.Item.Name,
 		Position: state.ProgressMs,
 		Playing:  state.IsPlaying,

--- a/services/spotify/spotify.go
+++ b/services/spotify/spotify.go
@@ -64,15 +64,18 @@ func (c *Client) State() (*player.State, error) {
 		return nil, err
 	}
 
-	query := ""
-	for _, a := range state.Item.Artists {
-		query += a.Name + " "
+	artist := ""
+	for i, a := range state.Item.Artists {
+		if i != 0 {
+			artist += " "
+		}
+		artist += a.Name
 	}
-	query += state.Item.Name
 
 	return &player.State{
 		ID:       state.Item.ID,
-		Query:    query,
+		Artist:   artist,
+		Track:    state.Item.Name,
 		Position: state.ProgressMs,
 		Playing:  state.IsPlaying,
 	}, nil


### PR DESCRIPTION
First Cyrillic char in synced lyrics sometimes came out as `�`. The parser did `line[11:]` assuming a space after `]` — without one, the slice cut a two-byte UTF-8 char in half. Metadata tags like `[ar:...]` and `[ti:...]` also slipped through as garbage lyric lines.

What changed:

- LRC parser finds `]` instead of guessing offset 11. Handles `[00:17.12]` and `[00:17.123]`, space or no space. Skips non-timestamp lines. `IsTimestampLine` / `ParseLrcLine` moved to the `lyrics` package, shared by `local` and `lrclib`;
- lrclib client: if artist and track are both known, calls `/api/get`, otherwise `/api/search`;
- `Lyrics(id, query string)` → `Lyrics(artist, track string)`. The `id` was a Spotify track ID lrclib ignored anyway. `player.State.Query` split into `Artist` / `Track`; all five player backends already had both values, they were just gluing them together.