### PR TITLE
Show message when no lyrics are available

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -113,7 +113,13 @@ func (m *Model) View() string {
 		)
 	}
 	if len(m.state.Lines) == 0 {
-		return ""
+		return gloss.PlaceVertical(
+			m.h, gloss.Center,
+			m.styleCurrent.
+				Align(gloss.Center).
+				Width(m.w).
+				Render("No lyrics found"),
+		)
 	}
 
 	curLine := m.styleCurrent.


### PR DESCRIPTION
When a track has no lyrics, the screen goes blank with no indication of what happened. Users can't tell whether lyrics are loading, missing, or broken.

This displays a "No lyrics found for this track" message instead of showing nothing.

Fixes #55